### PR TITLE
Added ANCMTestFlags environment variable

### DIFF
--- a/test/AspNetCoreModule.Test/FunctionalTest.cs
+++ b/test/AspNetCoreModule.Test/FunctionalTest.cs
@@ -12,7 +12,7 @@ namespace AspNetCoreModule.Test
     public class FunctionalTest : FunctionalTestHelper, IClassFixture<InitializeTestMachine>
     {
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.noChange)]
@@ -23,7 +23,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.noChange, 5)]
@@ -36,7 +36,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, 25, 19)]
@@ -51,7 +51,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, 10)]
@@ -64,7 +64,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -75,7 +75,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -86,7 +86,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -97,7 +97,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -108,7 +108,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -119,7 +119,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData("ANCMTestBar", "bar", "bar", IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -136,7 +136,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -147,7 +147,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -158,7 +158,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789")]
@@ -169,7 +169,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -180,7 +180,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, 10)]
@@ -191,7 +191,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "00:02:00")]
@@ -204,7 +204,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -215,7 +215,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "dotnet.exe", "./")]
@@ -228,7 +228,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, true)]
@@ -241,7 +241,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, true, true)]
@@ -254,7 +254,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -265,7 +265,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -276,7 +276,7 @@ namespace AspNetCoreModule.Test
         }
         
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, true)]
@@ -291,7 +291,7 @@ namespace AspNetCoreModule.Test
         // NOTE: below test scenarios are not valid for Win7 OS
         //////////////////////////////////////////////////////////
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, SkipReason = "IIS does not support Websocket on Win7")]
@@ -303,7 +303,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestSkipCondition("RunAsAdministratorAndX64Bitness")]
+        [ANCMTestSkipCondition("%ANCMTestFlags%")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, SkipReason = "WAS does not handle private memory limitation with Job object on Win7")]

--- a/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
+++ b/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
@@ -37,29 +37,42 @@ namespace AspNetCoreModule.Test
             get
             {
                 bool result = true;
-                if (_environmentVariableName == "RunAsAdministratorAndX64Bitness")
+                if (_environmentVariableName == "%ANCMTestFlags%")
                 {
-                    try
+                    var envValue = Environment.ExpandEnvironmentVariables(_environmentVariableName);
+                    if (envValue == "")
                     {
-                        if (Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess)
-                        {
-                            throw new System.InvalidOperationException("this should be started with x64 process mode on 64 bit machine");
-                        }
-
-                        bool isElevated;
-                        WindowsIdentity identity = WindowsIdentity.GetCurrent();
-                        WindowsPrincipal principal = new WindowsPrincipal(identity);
-                        isElevated = principal.IsInRole(WindowsBuiltInRole.Administrator);
-                        if (!isElevated)
-                        {
-                            throw new System.ApplicationException("this should be started as an administrator");
-                        }
+                        envValue = "AdminAnd64Bit";
                     }
-                    catch (Exception ex)
+                    switch (envValue)
                     {
-                        AdditionalInfo = ex.Message;
+                        case "AdminAnd64Bit":
+                            try
+                            {
+                                if (Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess)
+                                {
+                                    throw new System.InvalidOperationException("this should be started with x64 process mode on 64 bit machine");
+                                }
 
-                        result = false;
+                                bool isElevated;
+                                WindowsIdentity identity = WindowsIdentity.GetCurrent();
+                                WindowsPrincipal principal = new WindowsPrincipal(identity);
+                                isElevated = principal.IsInRole(WindowsBuiltInRole.Administrator);
+                                if (!isElevated)
+                                {
+                                    throw new System.ApplicationException("this should be started as an administrator");
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                AdditionalInfo = ex.Message;
+
+                                result = false;
+                            }
+                            break;
+                        case "SkipTest":
+                            result = false;
+                            break;
                     }
                 }
                 return result;


### PR DESCRIPTION
@shirhatti @pan-wang 

Added a new environment variable.
If you want to skip ANCM test, you can run below commands before executing ".\build.cmd".

    Set ANCMTestFlags=SkipTest
    or
    $env:ANCMTestFlags="SkipTest"