### PR TITLE
Ensure .NET Core 1.0.5 is installed

### DIFF
--- a/build/repo.props
+++ b/build/repo.props
@@ -1,5 +1,6 @@
 <Project>
   <ItemGroup>
+    <DotNetCoreRuntime Include="1.0.5" />
     <ExcludeFromTest Include="$(RepositoryRoot)test\AspNetCoreModule.TestSites.Standard\*.csproj" />
     <ExcludeFromTest Include="$(RepositoryRoot)test\AspNetCoreModule.Test\*.csproj" Condition="'$(OS)' != 'Windows_NT'" />
   </ItemGroup>

--- a/test/AspNetCoreModule.TestSites.Standard/AspNetCoreModule.TestSites.Standard.csproj
+++ b/test/AspNetCoreModule.TestSites.Standard/AspNetCoreModule.TestSites.Standard.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <RuntimeFrameworkVersion>1.0.5</RuntimeFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.*" />


### PR DESCRIPTION
KoreBuild will stop installing this runtime soon. This ensures that the runtime will continue to be installed in this project.

cref https://github.com/aspnet/BuildTools/issues/347