### PR TITLE
Fix the uninitialized g_hWinHttpModule global variable to avoid empty error messages

### DIFF
--- a/src/AspNetCore/Src/dllmain.cpp
+++ b/src/AspNetCore/Src/dllmain.cpp
@@ -191,6 +191,7 @@ HRESULT
     g_pModuleId = pModuleInfo->GetId();
     g_pszModuleName = pModuleInfo->GetName();
     g_pHttpServer = pHttpServer;
+    g_hWinHttpModule = GetModuleHandle(TEXT("winhttp.dll"));
 
     //
     // WinHTTP does not create enough threads, ask it to create more.

--- a/src/AspNetCore/Src/forwardinghandler.cxx
+++ b/src/AspNetCore/Src/forwardinghandler.cxx
@@ -1447,9 +1447,8 @@ Failure:
     //
     pResponse->SetStatus(502, "Bad Gateway", 3, hr);
 
-    if (hr > HRESULT_FROM_WIN32(WINHTTP_ERROR_BASE) &&
-        hr <= HRESULT_FROM_WIN32(WINHTTP_ERROR_LAST))
-    {
+    if (!(hr > HRESULT_FROM_WIN32(WINHTTP_ERROR_BASE) &&
+          hr <= HRESULT_FROM_WIN32(WINHTTP_ERROR_LAST)) ||
 #pragma prefast (suppress : __WARNING_FUNCTION_NEEDS_REVIEW, "Function and parameters reviewed.")
         FormatMessage(
             FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_HMODULE,
@@ -1458,9 +1457,7 @@ Failure:
             0,
             strDescription.QueryStr(),
             strDescription.QuerySizeCCH(),
-            NULL);
-    }
-    else
+            NULL) == 0)
     {
         LoadString(g_hModule,
             IDS_SERVER_ERROR,
@@ -1770,9 +1767,8 @@ REQUEST_NOTIFICATION_STATUS
 
             pResponse->SetStatus(502, "Bad Gateway", 3, hr);
 
-            if (hr > HRESULT_FROM_WIN32(WINHTTP_ERROR_BASE) &&
-                hr <= HRESULT_FROM_WIN32(WINHTTP_ERROR_LAST))
-            {
+            if (!(hr > HRESULT_FROM_WIN32(WINHTTP_ERROR_BASE) &&
+                  hr <= HRESULT_FROM_WIN32(WINHTTP_ERROR_LAST)) ||
 #pragma prefast (suppress : __WARNING_FUNCTION_NEEDS_REVIEW, "Function and parameters reviewed.")
                 FormatMessage(
                     FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_HMODULE,
@@ -1781,15 +1777,14 @@ REQUEST_NOTIFICATION_STATUS
                     0,
                     strDescription.QueryStr(),
                     strDescription.QuerySizeCCH(),
-                    NULL);
-            }
-            else
+                    NULL) == 0)
             {
                 LoadString(g_hModule,
                     IDS_SERVER_ERROR,
                     strDescription.QueryStr(),
                     strDescription.QuerySizeCCH());
             }
+
             (VOID)strDescription.SyncWithBuffer();
             if (strDescription.QueryCCH() != 0)
             {
@@ -2375,9 +2370,8 @@ Failure:
 
             pResponse->SetStatus(502, "Bad Gateway", 3, hr);
 
-            if (hr > HRESULT_FROM_WIN32(WINHTTP_ERROR_BASE) &&
-                hr <= HRESULT_FROM_WIN32(WINHTTP_ERROR_LAST))
-            {
+            if (!(hr > HRESULT_FROM_WIN32(WINHTTP_ERROR_BASE) &&
+                  hr <= HRESULT_FROM_WIN32(WINHTTP_ERROR_LAST)) ||
 #pragma prefast (suppress : __WARNING_FUNCTION_NEEDS_REVIEW, "Function and parameters reviewed.")
                 FormatMessage(
                     FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_HMODULE,
@@ -2386,15 +2380,14 @@ Failure:
                     0,
                     strDescription.QueryStr(),
                     strDescription.QuerySizeCCH(),
-                    NULL);
-            }
-            else
+                    NULL) == 0)
             {
                 LoadString(g_hModule,
                     IDS_SERVER_ERROR,
                     strDescription.QueryStr(),
                     strDescription.QuerySizeCCH());
             }
+
             strDescription.SyncWithBuffer();
             if (strDescription.QueryCCH() != 0)
             {


### PR DESCRIPTION
Fixes #224

Feel free to discard this pull request, because I am not quite confident in my C++ skills — this might be completely wrong way to fix the issue. Also, I was not able to test it 😞 

- Assign module handle of winhttp.dll to `g_hWinHttpModule` in `RegisterModule` function.
 
- Lots of error codes between `WINHTTP_ERROR_BASE` and `WINHTTP_ERROR_LAST` do not
have corresponding entries in winhttp.dll message resource table; use defensive
coding to fall back to the default error message (`IDS_SERVER_ERROR`) when necessary.

For example, winhttp.dll on Windows Server 2012 R2 does not have message resource for `ERROR_WINHTTP_INVALID_HEADER`.

Running this code snippet will demonstrate that most valid error codes do not have corresponding message resources:

```c++
DWORD dwError = ERROR_SUCCESS;
HMODULE g_hWinHttpModule = GetModuleHandle(TEXT("winhttp.dll"));
TCHAR msgBuffer[0x10000 / sizeof(TCHAR)];  // Max size of buffer is 64K bytes

for (DWORD winHttpError = WINHTTP_ERROR_BASE + 1;
           winHttpError <= WINHTTP_ERROR_LAST;
           winHttpError++)
{
    memset(msgBuffer, 0, sizeof msgBuffer);

    if (FormatMessage(
        FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_HMODULE,
        g_hWinHttpModule,
        winHttpError,
        0,
        msgBuffer,
        ARRAYSIZE(msgBuffer),
        NULL) == 0)
    {
        dwError = GetLastError();

        // "The system cannot find message text for message number 0x%1 in the message file for %2."
        if (dwError == ERROR_MR_MID_NOT_FOUND) {
            _ftprintf_s(stderr, _T("ERROR: %lu => Message not found!\r\n"), winHttpError);
        } else {
            _ftprintf_s(stderr, _T("ERROR: %lu => %lu\r\n"), winHttpError, dwError);
        }
    }
    else
    {
        _ftprintf_s(stdout, _T("MESSAGE: %lu => %s"), winHttpError, msgBuffer);
    }
}
```