### PR TITLE
Add location information to ANCM package

### DIFF
--- a/nuget/AspNetCore.nuspec
+++ b/nuget/AspNetCore.nuspec
@@ -20,5 +20,6 @@
     <file src="..\artifacts\build\AspNetCore\bin\Release\x64\*.xml"/>
     <file src="..\tools\installancm.ps1"/>
     <file src="..\LICENSE.txt"/>
+    <file src="Microsoft.AspNetCore.AspNetCoreModule.props" target="build\" />
   </files>
 </package>

--- a/nuget/Microsoft.AspNetCore.AspNetCoreModule.props
+++ b/nuget/Microsoft.AspNetCore.AspNetCoreModule.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <PropertyGroup>
+    <AspNetCoreModuleX64Location>$(MSBuildThisFileDirectory)..\runtimes\win7\native\aspnetcore_x64.dll</AspNetCoreModuleX64Location>
+    <AspNetCoreModuleX86Location>$(MSBuildThisFileDirectory)..\runtimes\win7\native\aspnetcore_x86.dll</AspNetCoreModuleX86Location>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
So package consumers have an easy way of finding dlls