### PR TITLE
redirect stdout to log file + minor change to allow debug build

### DIFF
--- a/src/AspNetCore/AspNetCore.vcxproj
+++ b/src/AspNetCore/AspNetCore.vcxproj
@@ -103,6 +103,7 @@
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <AdditionalIncludeDirectories>..\IISLib;.\Inc</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/AspNetCore/Inc/aspnetcoreconfig.h
+++ b/src/AspNetCore/Inc/aspnetcoreconfig.h
@@ -60,6 +60,13 @@ public:
         delete this;
     }
 
+    HRESULT
+    CreateLogFile(
+        _In_  BOOL    fIgnoreDisableInConfig,
+        _Out_ STRU*   pstruFullFileName,
+        _Out_ HANDLE* pHandle
+    );
+
     static
     HRESULT
     GetConfig(

--- a/src/AspNetCore/Inc/inprocessapplication.h
+++ b/src/AspNetCore/Inc/inprocessapplication.h
@@ -95,6 +95,7 @@ private:
     // The event that gets triggered when managed initialization is complete
     HANDLE                          m_pInitalizeEvent;
     HANDLE                          m_hLogFileHandle;
+    STRU                            m_struLogFilePath;
     // The exit code of the .NET Core process
     INT                             m_ProcessExitCode;
 
@@ -104,6 +105,7 @@ private:
     BOOL                            m_fIsWebSocketsConnection;
     BOOL                            m_fDoneStdRedirect;
     FILE*                           m_pStdFile;
+    STTIMER                         m_Timer;
 
     static IN_PROCESS_APPLICATION*   s_Application;
 

--- a/src/AspNetCore/Inc/inprocessapplication.h
+++ b/src/AspNetCore/Inc/inprocessapplication.h
@@ -45,6 +45,11 @@ public:
         _In_ VOID* pvShutdownHandlerContext
     );
 
+    VOID
+    SetStdOut(
+        VOID
+    );
+
     // Executes the .NET Core process
     HRESULT
     ExecuteApplication(
@@ -89,7 +94,7 @@ private:
 
     // The event that gets triggered when managed initialization is complete
     HANDLE                          m_pInitalizeEvent;
-
+    HANDLE                          m_hLogFileHandle;
     // The exit code of the .NET Core process
     INT                             m_ProcessExitCode;
 
@@ -97,6 +102,8 @@ private:
     BOOL                            m_fLoadManagedAppError;
     BOOL                            m_fInitialized;
     BOOL                            m_fIsWebSocketsConnection;
+    BOOL                            m_fDoneStdRedirect;
+    FILE*                           m_pStdFile;
 
     static IN_PROCESS_APPLICATION*   s_Application;
 

--- a/src/AspNetCore/Src/dllmain.cpp
+++ b/src/AspNetCore/Src/dllmain.cpp
@@ -4,13 +4,6 @@
 #include "precomp.hxx"
 #include <IPHlpApi.h>
 
-#ifdef DEBUG
-    DECLARE_DEBUG_PRINTS_OBJECT();
-    DECLARE_DEBUG_VARIABLE();
-    DECLARE_PLATFORM_TYPE();
-#endif // DEBUG
-
-
 HTTP_MODULE_ID      g_pModuleId = NULL;
 IHttpServer *       g_pHttpServer = NULL;
 BOOL                g_fAsyncDisconnectAvailable = FALSE;

--- a/src/AspNetCore/Src/forwardinghandler.cxx
+++ b/src/AspNetCore/Src/forwardinghandler.cxx
@@ -4,7 +4,8 @@
 #include "precomp.hxx"
 #include <dbgutil.h>
 #include <comdef.h>
-
+#include <io.h>
+#include <stdio.h>
 
 // Just to be aware of the FORWARDING_HANDLER object size.
 C_ASSERT(sizeof(FORWARDING_HANDLER) <= 632);
@@ -1142,7 +1143,8 @@ FORWARDING_HANDLER::OnExecuteRequestHandler(
     {
     case HOSTING_IN_PROCESS:
     {
-
+        // Set Stdout
+        ((IN_PROCESS_APPLICATION*)m_pApplication)->SetStdOut();
         hr = ((IN_PROCESS_APPLICATION*)m_pApplication)->LoadManagedApplication();
         if (FAILED(hr))
         {

--- a/src/AspNetCore/Src/forwardinghandler.cxx
+++ b/src/AspNetCore/Src/forwardinghandler.cxx
@@ -4,8 +4,6 @@
 #include "precomp.hxx"
 #include <dbgutil.h>
 #include <comdef.h>
-#include <io.h>
-#include <stdio.h>
 
 // Just to be aware of the FORWARDING_HANDLER object size.
 C_ASSERT(sizeof(FORWARDING_HANDLER) <= 632);

--- a/src/AspNetCore/Src/inprocessapplication.cxx
+++ b/src/AspNetCore/Src/inprocessapplication.cxx
@@ -504,14 +504,14 @@ IN_PROCESS_APPLICATION::Recycle(
             fclose(m_pStdFile);
         }
 
-        // delete empty log file
-        if (!m_struLogFilePath.IsEmpty())
+        // delete empty log file, if logging is not enabled
+        if (!m_pConfiguration->QueryStdoutLogEnabled() && !m_struLogFilePath.IsEmpty())
         {
             WIN32_FIND_DATA fileData;
             HANDLE handle = FindFirstFile(m_struLogFilePath.QueryStr(), &fileData);
-            if (handle != INVALID_HANDLE_VALUE && 
-                fileData.nFileSizeHigh == 0 && 
-                fileData.nFileSizeLow ==0)
+            if (handle != INVALID_HANDLE_VALUE &&
+                fileData.nFileSizeHigh &&
+                fileData.nFileSizeLow ==0) // skip check of nFileSizeHigh
             {
                 FindClose(handle);
                 // no need to check whether the deletion succeeds

--- a/src/AspNetCore/Src/inprocessapplication.cxx
+++ b/src/AspNetCore/Src/inprocessapplication.cxx
@@ -4,7 +4,6 @@
 #include "precomp.hxx"
 #include <algorithm>
 
-
 typedef DWORD(*hostfxr_main_fn) (CONST DWORD argc, CONST WCHAR* argv[]);
 
 IN_PROCESS_APPLICATION*  IN_PROCESS_APPLICATION::s_Application = NULL;

--- a/src/AspNetCore/Src/inprocessapplication.cxx
+++ b/src/AspNetCore/Src/inprocessapplication.cxx
@@ -4,6 +4,7 @@
 #include "precomp.hxx"
 #include <algorithm>
 
+
 typedef DWORD(*hostfxr_main_fn) (CONST DWORD argc, CONST WCHAR* argv[]);
 
 IN_PROCESS_APPLICATION*  IN_PROCESS_APPLICATION::s_Application = NULL;
@@ -12,7 +13,9 @@ IN_PROCESS_APPLICATION::IN_PROCESS_APPLICATION() :
     m_ProcessExitCode ( 0 ),
     m_fManagedAppLoaded ( FALSE ),
     m_fLoadManagedAppError ( FALSE ),
-    m_fInitialized ( FALSE )
+    m_fInitialized ( FALSE ),
+    m_pStdFile ( NULL ),
+    m_hLogFileHandle (INVALID_HANDLE_VALUE)
 {
 }
 
@@ -129,6 +132,120 @@ IN_PROCESS_APPLICATION::FindDotNetFolders(
     } while (FindNextFileW(handle, &data));
 
     FindClose(handle);
+}
+
+VOID
+IN_PROCESS_APPLICATION::SetStdOut(
+    VOID
+)
+{
+    HRESULT      hr = S_OK;
+    STRU         struLogFileName;
+    BOOL         fLocked = FALSE;
+    BOOL         fResult = FALSE;
+
+    if (!m_fDoneStdRedirect)
+    {
+        // Have not set stdout yet, redirect stdout to log file
+        AcquireSRWLockExclusive(&m_srwLock);
+        fLocked = TRUE;
+        if (!m_fDoneStdRedirect)
+        {
+            //
+            // best effort
+            // no need to capture the error code as nothing we can do here
+            // in case mamanged layer exits abnormally, may not be able to capture the log content as it is buffered.
+            //
+            if (!GetConsoleWindow())
+            {
+                hr = m_pConfiguration->CreateLogFile(TRUE, &struLogFileName, &m_hLogFileHandle);
+                if (FAILED(hr))
+                {
+                    goto Finished;
+                }
+                //
+                // SetStdHandle works as w3wp does not have Console
+                // Current process does not have a console
+                //
+                SetStdHandle(STD_ERROR_HANDLE, m_hLogFileHandle);
+                if (m_pConfiguration->QueryStdoutLogEnabled())
+                {
+                    SetStdHandle(STD_OUTPUT_HANDLE, m_hLogFileHandle);
+                    // not work
+                   // *stdout = *m_pStdFile;
+                   // *stderr = *m_pStdFile;
+                   // _dup2(_fileno(m_pStdFile), _fileno(stdout));
+                   // _dup2(_fileno(m_pStdFile), _fileno(stderr));
+                   // this one cannot capture the process start failure
+                   // _wfreopen_s(&m_pStdFile, struLogFileName.QueryStr(), L"w", stdout);
+                }
+            }
+            else
+            {
+                if (m_pConfiguration->QueryStdoutLogEnabled())
+                {
+                    hr = m_pConfiguration->CreateLogFile(TRUE, &struLogFileName, &m_hLogFileHandle);
+                    if (FAILED(hr))
+                    {
+                        goto Finished;
+                    }
+
+                    // The process has console, e.g., IIS Express scenario
+                    CloseHandle(m_hLogFileHandle);
+                    m_hLogFileHandle = INVALID_HANDLE_VALUE;
+                    if (_wfopen_s(&m_pStdFile, struLogFileName.QueryStr(), L"w") == 0)
+                    {
+                        // known issue: error info may not be capture when process crashes during buffering
+                        // even we disabled FILE buffering
+                        setvbuf(m_pStdFile, NULL, _IONBF, 0);
+                        _dup2(_fileno(m_pStdFile), _fileno(stdout));
+                        _dup2(_fileno(m_pStdFile), _fileno(stderr));
+                    }
+                    // not work for console scenario
+                    //_wfreopen_s(&m_pStdFile, struLogFileName.QueryStr(), L"w", stdout);
+                    // SetStdHandle(STD_ERROR_HANDLE, m_hLogFileHandle);
+                    // SetStdHandle(STD_OUTPUT_HANDLE, m_hLogFileHandle);
+                    //*stdout = *m_pStdFile;
+                    //*stderr = *m_pStdFile;
+                }
+            }
+        }
+    }
+Finished:
+    m_fDoneStdRedirect = TRUE;
+    if(fLocked)
+    {
+        ReleaseSRWLockExclusive(&m_srwLock);
+    }
+    if (FAILED(hr) && m_pConfiguration->QueryStdoutLogEnabled())
+    {
+        STRU                    strEventMsg;
+        LPCWSTR                 apsz[1];
+
+        if (SUCCEEDED(strEventMsg.SafeSnwprintf(
+            ASPNETCORE_EVENT_INVALID_STDOUT_LOG_FILE_MSG,
+            struLogFileName.QueryStr(),
+            HRESULT_FROM_GETLASTERROR())))
+        {
+            apsz[0] = strEventMsg.QueryStr();
+            //
+            // not checking return code because if ReportEvent
+            // fails, we cannot do anything.
+            //
+            if (FORWARDING_HANDLER::QueryEventLog() != NULL)
+            {
+                ReportEventW(FORWARDING_HANDLER::QueryEventLog(),
+                    EVENTLOG_WARNING_TYPE,
+                    0,
+                    ASPNETCORE_EVENT_CONFIG_ERROR,
+                    NULL,
+                    1,
+                    0,
+                    apsz,
+                    NULL);
+            }
+        }
+    }
 }
 
 VOID
@@ -367,6 +484,19 @@ IN_PROCESS_APPLICATION::Recycle(
         CloseHandle(m_hThread);
         m_hThread = NULL;
         s_Application = NULL;
+
+        if (m_hLogFileHandle != INVALID_HANDLE_VALUE)
+        {
+            CloseHandle(m_hLogFileHandle);
+            m_hLogFileHandle = INVALID_HANDLE_VALUE;
+        }
+
+        if (m_pStdFile != NULL)
+        {
+            fflush(stdout);
+            fflush(stderr);
+            fclose(m_pStdFile);
+        }
 
         ReleaseSRWLockExclusive(&m_srwLock);
         if (g_pHttpServer && g_pHttpServer->IsCommandLineLaunch())

--- a/src/AspNetCore/Src/precomp.hxx
+++ b/src/AspNetCore/Src/precomp.hxx
@@ -110,6 +110,8 @@ inline bool IsSpace(char ch)
 #include <reftrace.h>
 #include <acache.h>
 #include <time.h>
+#include <io.h>
+#include <stdio.h>
 
 #include "environmentvariablehash.h"
 #include "..\aspnetcore_msg.h"

--- a/src/AspNetCore/Src/serverprocess.cxx
+++ b/src/AspNetCore/Src/serverprocess.cxx
@@ -1259,7 +1259,7 @@ SERVER_PROCESS::SetupStdHandles(
             m_struFullLogFile.Copy(struLogFileName);
 
             // start timer to open and close handles regularly.
-            m_Timer.InitializeTimer(SERVER_PROCESS::TimerCallback, this, 3000, 3000);
+            m_Timer.InitializeTimer(SERVER_PROCESS::TimerCallback, &m_struFullLogFile, 3000, 3000);
         }
     }
 
@@ -1288,7 +1288,7 @@ SERVER_PROCESS::TimerCallback(
 {
     Instance;
     Timer;
-    SERVER_PROCESS*         pServerProcess = (SERVER_PROCESS*) Context;
+    STRU*                   pstruLogFilePath = (STRU*)Context;
     HANDLE                  hStdoutHandle = NULL;
     SECURITY_ATTRIBUTES     saAttr = {0};
     HRESULT                 hr = S_OK;
@@ -1297,7 +1297,7 @@ SERVER_PROCESS::TimerCallback(
     saAttr.bInheritHandle = TRUE; 
     saAttr.lpSecurityDescriptor = NULL;
 
-    hStdoutHandle = CreateFileW(pServerProcess->QueryFullLogPath(),
+    hStdoutHandle = CreateFileW(pstruLogFilePath->QueryStr(),
                                 FILE_READ_DATA,
                                 FILE_SHARE_WRITE,
                                 &saAttr,


### PR DESCRIPTION
For inprocess scenario, we redirect the stdout and stderr to a file handle using SetStdHandle API.
We always redirect the stderr even though user does not enable logging in web.config. This will help us to capture the start failure of managed application. Empty logging file will be deleted if logging is not enabled.
some small changes for out-of-process logging to make it consistent with inprocess logging.
A small change in project file to allow debug build. 
