### PR TITLE
Disable tests for continuous integration. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,4 @@ src/AspNetCore/version.h
 
 *.VC.*db
 global.json
-korebuild-lock.txt
 

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,0 +1,2 @@
+version:2.1.0-preview1-15552
+commithash:4af2f444ec8cba0faa866dd867370e6aa6df69ea

--- a/test/AspNetCoreModule.Test/Framework/InitializeTestMachine.cs
+++ b/test/AspNetCoreModule.Test/Framework/InitializeTestMachine.cs
@@ -22,6 +22,7 @@ namespace AspNetCoreModule.Test.Framework
         public const string UrlRewriteModuleAvailable = "UrlRewriteModuleAvailable";
         public const string X86Platform = "X86Platform";
         public const string Wow64BitMode = "Wow64BitMode";
+        public const string RequireRunAsAdministrator = "RequireRunAsAdministrator";
         public const string Default = "Default";
 
         public static bool Enabled(string flagValue)

--- a/test/AspNetCoreModule.Test/Framework/InitializeTestMachine.cs
+++ b/test/AspNetCoreModule.Test/Framework/InitializeTestMachine.cs
@@ -22,7 +22,6 @@ namespace AspNetCoreModule.Test.Framework
         public const string UrlRewriteModuleAvailable = "UrlRewriteModuleAvailable";
         public const string X86Platform = "X86Platform";
         public const string Wow64BitMode = "Wow64BitMode";
-        public const string RequireRunAsAdministrator = "RequireRunAsAdministrator";
         public const string Default = "Default";
 
         public static bool Enabled(string flagValue)

--- a/test/AspNetCoreModule.Test/Framework/InitializeTestMachine.cs
+++ b/test/AspNetCoreModule.Test/Framework/InitializeTestMachine.cs
@@ -27,7 +27,7 @@ namespace AspNetCoreModule.Test.Framework
 
         public static bool Enabled(string flagValue)
         {
-            return InitializeTestMachine.GlobalTestFlags.Contains(flagValue.ToLower());
+            return InitializeTestMachine.GlobalTestFlags.IndexOf(flagValue, StringComparison.OrdinalIgnoreCase) > -1;
         }
     }
 

--- a/test/AspNetCoreModule.Test/FunctionalTest.cs
+++ b/test/AspNetCoreModule.Test/FunctionalTest.cs
@@ -12,7 +12,7 @@ namespace AspNetCoreModule.Test
     public class FunctionalTest : FunctionalTestHelper, IClassFixture<InitializeTestMachine>
     {
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.noChange)]
@@ -23,7 +23,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.noChange, 5)]
@@ -36,7 +36,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, 25, 19, false)]
@@ -57,7 +57,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, 10)]
@@ -70,7 +70,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -81,7 +81,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -92,7 +92,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -103,7 +103,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -114,7 +114,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -125,7 +125,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData("ANCMTestBar", "bar", "bar", IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -142,7 +142,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -153,7 +153,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -164,7 +164,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789")]
@@ -175,7 +175,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -186,7 +186,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, 10)]
@@ -197,7 +197,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "00:02:00")]
@@ -210,7 +210,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -221,7 +221,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "dotnet.exe", "./")]
@@ -234,7 +234,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, true)]
@@ -247,7 +247,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, true, true)]
@@ -260,7 +260,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -271,7 +271,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -282,7 +282,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "MS-ASPNETCORE", "f")]
@@ -297,7 +297,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, true)]
@@ -309,7 +309,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.noChange, false, DoAppVerifierTest_StartUpMode.UseGracefulShutdown, DoAppVerifierTest_ShutDownMode.RecycleAppPool, 1)]
@@ -325,7 +325,7 @@ namespace AspNetCoreModule.Test
         //////////////////////////////////////////////////////////
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -339,7 +339,7 @@ namespace AspNetCoreModule.Test
         // NOTE: below test scenarios are not valid for Win7 OS
         //////////////////////////////////////////////////////////
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, SkipReason = "IIS does not support Websocket on Win7")]
@@ -353,7 +353,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.SkipTest)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, SkipReason = "WAS does not handle private memory limitation with Job object on Win7")]

--- a/test/AspNetCoreModule.Test/FunctionalTest.cs
+++ b/test/AspNetCoreModule.Test/FunctionalTest.cs
@@ -12,7 +12,7 @@ namespace AspNetCoreModule.Test
     public class FunctionalTest : FunctionalTestHelper, IClassFixture<InitializeTestMachine>
     {
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.noChange)]
@@ -23,7 +23,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.noChange, 5)]
@@ -36,7 +36,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, 25, 19, false)]
@@ -57,7 +57,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, 10)]
@@ -70,7 +70,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -81,7 +81,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -92,7 +92,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -103,7 +103,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -114,7 +114,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -125,7 +125,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData("ANCMTestBar", "bar", "bar", IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -142,7 +142,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -153,7 +153,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -164,7 +164,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789")]
@@ -175,7 +175,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -186,7 +186,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, 10)]
@@ -197,7 +197,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "00:02:00")]
@@ -210,7 +210,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -221,7 +221,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "dotnet.exe", "./")]
@@ -234,7 +234,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, true)]
@@ -247,7 +247,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, true, true)]
@@ -260,7 +260,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -271,7 +271,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -282,7 +282,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "MS-ASPNETCORE", "f")]
@@ -297,7 +297,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, true)]
@@ -309,7 +309,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.noChange, false, DoAppVerifierTest_StartUpMode.UseGracefulShutdown, DoAppVerifierTest_ShutDownMode.RecycleAppPool, 1)]
@@ -325,7 +325,7 @@ namespace AspNetCoreModule.Test
         //////////////////////////////////////////////////////////
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -339,7 +339,7 @@ namespace AspNetCoreModule.Test
         // NOTE: below test scenarios are not valid for Win7 OS
         //////////////////////////////////////////////////////////
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, SkipReason = "IIS does not support Websocket on Win7")]
@@ -353,7 +353,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.RequireRunAsAdministrator)]
+        [ANCMTestFlags(TestFlags.RunAsAdministrator)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, SkipReason = "WAS does not handle private memory limitation with Job object on Win7")]

--- a/test/AspNetCoreModule.Test/FunctionalTest.cs
+++ b/test/AspNetCoreModule.Test/FunctionalTest.cs
@@ -11,8 +11,10 @@ namespace AspNetCoreModule.Test
 {
     public class FunctionalTest : FunctionalTestHelper, IClassFixture<InitializeTestMachine>
     {
+        private const string ANCMTestCondition = TestFlags.SkipTest;
+
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.noChange)]
@@ -23,7 +25,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.noChange, 5)]
@@ -36,7 +38,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, 25, 19, false)]
@@ -57,7 +59,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, 10)]
@@ -70,7 +72,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -81,7 +83,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -92,7 +94,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -103,7 +105,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -114,7 +116,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -125,7 +127,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData("ANCMTestBar", "bar", "bar", IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -142,7 +144,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -153,7 +155,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -164,7 +166,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789")]
@@ -175,7 +177,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -186,7 +188,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, 10)]
@@ -197,7 +199,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "00:02:00")]
@@ -210,7 +212,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -221,7 +223,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "dotnet.exe", "./")]
@@ -234,7 +236,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, true)]
@@ -247,7 +249,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, true, true)]
@@ -260,7 +262,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -271,7 +273,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -282,7 +284,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, "MS-ASPNETCORE", "f")]
@@ -297,7 +299,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit, true)]
@@ -309,7 +311,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.noChange, false, DoAppVerifierTest_StartUpMode.UseGracefulShutdown, DoAppVerifierTest_ShutDownMode.RecycleAppPool, 1)]
@@ -325,7 +327,7 @@ namespace AspNetCoreModule.Test
         //////////////////////////////////////////////////////////
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(IISConfigUtility.AppPoolBitness.enable32Bit)]
@@ -339,7 +341,7 @@ namespace AspNetCoreModule.Test
         // NOTE: below test scenarios are not valid for Win7 OS
         //////////////////////////////////////////////////////////
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, SkipReason = "IIS does not support Websocket on Win7")]
@@ -353,7 +355,7 @@ namespace AspNetCoreModule.Test
         }
 
         [ConditionalTheory]
-        [ANCMTestFlags(TestFlags.SkipTest)]
+        [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, SkipReason = "WAS does not handle private memory limitation with Job object on Win7")]

--- a/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
+++ b/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
@@ -29,7 +29,7 @@ namespace AspNetCoreModule.Test
         public ANCMTestFlags(string attributeValue)
         {
             _attributeValue = attributeValue.ToString();
-        }
+        }   
 
         public bool IsMet
         {
@@ -47,6 +47,7 @@ namespace AspNetCoreModule.Test
                     AdditionalInfo = _attributeValue + " is not belong to the given global test context(" + InitializeTestMachine.GlobalTestFlags + ")";
                     return false;
                 }
+
                 return true;
             }
         }

--- a/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
+++ b/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
@@ -35,8 +35,7 @@ namespace AspNetCoreModule.Test
         {
             get
             {
-                if (_attributeValue == TestFlags.SkipTest
-                    || TestFlags.Enabled(TestFlags.SkipTest))
+                if (_attributeValue == TestFlags.SkipTest)
                 {
                     AdditionalInfo = TestFlags.SkipTest + " is set";
                     return false;

--- a/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
+++ b/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
@@ -29,7 +29,7 @@ namespace AspNetCoreModule.Test
         public ANCMTestFlags(string attributeValue)
         {
             _attributeValue = attributeValue.ToString();
-        }   
+        }
 
         public bool IsMet
         {

--- a/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
+++ b/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
@@ -47,7 +47,6 @@ namespace AspNetCoreModule.Test
                     AdditionalInfo = _attributeValue + " is not belong to the given global test context(" + InitializeTestMachine.GlobalTestFlags + ")";
                     return false;
                 }
-
                 return true;
             }
         }

--- a/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
+++ b/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
@@ -35,14 +35,15 @@ namespace AspNetCoreModule.Test
         {
             get
             {
-                if (InitializeTestMachine.GlobalTestFlags.Contains(TestFlags.SkipTest))
+                if (_attributeValue == TestFlags.SkipTest
+                    || TestFlags.Enabled(TestFlags.SkipTest))
                 {
                     AdditionalInfo = TestFlags.SkipTest + " is set";
                     return false;
                 }
 
-                if (_attributeValue == TestFlags.RequireRunAsAdministrator 
-                    && !InitializeTestMachine.GlobalTestFlags.Contains(TestFlags.RunAsAdministrator))
+                if (_attributeValue == TestFlags.RunAsAdministrator 
+                    && !TestFlags.Enabled(TestFlags.RunAsAdministrator))
                 { 
                     AdditionalInfo = _attributeValue + " is not belong to the given global test context(" + InitializeTestMachine.GlobalTestFlags + ")";
                     return false;

--- a/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
+++ b/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
@@ -42,7 +42,7 @@ namespace AspNetCoreModule.Test
                     return false;
                 }
 
-                if (_attributeValue == TestFlags.RunAsAdministrator 
+                if (_attributeValue == TestFlags.RequireRunAsAdministrator 
                     && !TestFlags.Enabled(TestFlags.RunAsAdministrator))
                 { 
                     AdditionalInfo = _attributeValue + " is not belong to the given global test context(" + InitializeTestMachine.GlobalTestFlags + ")";

--- a/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
+++ b/test/AspNetCoreModule.Test/FunctionalTestHelper.cs
@@ -35,14 +35,14 @@ namespace AspNetCoreModule.Test
         {
             get
             {
-                if (TestFlags.Enabled(TestFlags.SkipTest))
+                if (InitializeTestMachine.GlobalTestFlags.Contains(TestFlags.SkipTest))
                 {
                     AdditionalInfo = TestFlags.SkipTest + " is set";
                     return false;
                 }
 
                 if (_attributeValue == TestFlags.RequireRunAsAdministrator 
-                    && !TestFlags.Enabled(TestFlags.RunAsAdministrator))
+                    && !InitializeTestMachine.GlobalTestFlags.Contains(TestFlags.RunAsAdministrator))
                 { 
                     AdditionalInfo = _attributeValue + " is not belong to the given global test context(" + InitializeTestMachine.GlobalTestFlags + ")";
                     return false;


### PR DESCRIPTION
[This change](https://github.com/aspnet/AspNetCoreModule/commit/192a403b9a782b7b692c9c35a48c0262e8a3ad8b) cause tests to be enabled on CI. I'm going to revert some of those change for now. @jhkimnew can you investigate what is wrong with this check?
/cc @ryanbrandenburg this should fix the build. 