### PR TITLE
Fixes dotnet.exe string as runtime now reads it

### DIFF
--- a/src/AspNetCore/Src/inprocessapplication.cxx
+++ b/src/AspNetCore/Src/inprocessapplication.cxx
@@ -579,12 +579,6 @@ IN_PROCESS_APPLICATION::ExecuteApplication(
     }
 
     // The first argument is mostly ignored
-    hr = strDotnetExeLocation.Append(pszDotnetExeString);
-    if (FAILED(hr))
-    {
-        goto Finished;
-    }
-
     argv[0] = strDotnetExeLocation.QueryStr();
     PATH::ConvertPathToFullPath(m_pConfiguration->QueryArguments()->QueryStr(),
                                 m_pConfiguration->QueryApplicationFullPath()->QueryStr(),


### PR DESCRIPTION
The first parameter in hostfxr main is now being read due to us picking up the latest cli. As this parameter is now used, the sample application was failing to load because I accidentally added the dotnet.exe path twice.
