### PR TITLE
Fixes back compat versioning issue

### DIFF
--- a/nuget/AspNetCore.nuspec
+++ b/nuget/AspNetCore.nuspec
@@ -20,6 +20,8 @@
   <files>
     <file src="..\artifacts\build\AspNetCore\bin\Release\Win32\aspnetcore.dll" target="contentFiles\any\any\x86\aspnetcore.dll" />
     <file src="..\artifacts\build\AspNetCore\bin\Release\x64\aspnetcore.dll" target="contentFiles\any\any\x64\aspnetcore.dll" />
+    <file src="..\artifacts\build\AspNetCore\bin\Release\Win32\aspnetcore.dll" target="runtimes\win7\native\aspnetcore_x86.dll" />
+    <file src="..\artifacts\build\AspNetCore\bin\Release\x64\aspnetcore.dll" target="runtimes\win7\native\aspnetcore_x64.dll" />
     <file src="..\artifacts\build\AspNetCore\bin\Release\x64\*.xml"/>
     <file src="..\tools\installancm.ps1"/>
     <file src="..\LICENSE.txt"/>


### PR DESCRIPTION
When changing the path to where aspnetcore was, I should have incremented the major version number of the AspNetCoreModule package. Issues arise when using older apps (1.0.x and 2.0.x) that are using floating version numbers. For now, we will have to bring back the other locations in the nupkg.