### PR TITLE
Excluding flaky tests first for CI

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -131,10 +131,6 @@ function Get-KoreBuild {
             Remove-Item $tmpfile -ErrorAction Ignore
         }
     }
-
-    $dotnetExeHome = Join-Path $DotNetHome "x64"
-    $env:PATH = "$dotnetExeHome;$env:PATH"
-
     return $korebuildPath
 }
 

--- a/run.ps1
+++ b/run.ps1
@@ -132,6 +132,9 @@ function Get-KoreBuild {
         }
     }
 
+    $dotnetExeHome = Join-Path $DotNetHome "x64"
+    $env:PATH = "$dotnetExeHome;$env:PATH"
+
     return $korebuildPath
 }
 

--- a/test/AspNetCoreModule.Test/FunctionalTest.cs
+++ b/test/AspNetCoreModule.Test/FunctionalTest.cs
@@ -37,7 +37,7 @@ namespace AspNetCoreModule.Test
             return DoRapidFailsPerMinuteTest(appPoolBitness, valueOfRapidFailsPerMinute);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Pending investigation for flakiness")]
         [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
@@ -48,7 +48,7 @@ namespace AspNetCoreModule.Test
             return DoShutdownTimeLimitTest(appPoolBitness, valueOfshutdownTimeLimit, expectedClosingTime, isGraceFullShutdownEnabled);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Pending investigation for flakiness")]
         [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
@@ -59,7 +59,7 @@ namespace AspNetCoreModule.Test
             return DoShutdownTimeLimitTest(appPoolBitness, valueOfshutdownTimeLimit, expectedClosingTime, isGraceFullShutdownEnabled);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Pending investigation for flakiness")]
         [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
@@ -70,7 +70,7 @@ namespace AspNetCoreModule.Test
             return DoShutdownTimeLimitTest(appPoolBitness, valueOfshutdownTimeLimit, expectedClosingTime, isGraceFullShutdownEnabled);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Pending investigation for flakiness")]
         [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
@@ -83,7 +83,7 @@ namespace AspNetCoreModule.Test
             return DoShutdownTimeLimitTest(appPoolBitness, valueOfshutdownTimeLimit, expectedClosingTime, isGraceFullShutdownEnabled);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Pending investigation for flakiness")]
         [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
@@ -343,7 +343,7 @@ namespace AspNetCoreModule.Test
             return DoFilterOutMSRequestHeadersTest(appPoolBitness, requestHeader, requestHeaderValue);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Pending investigation for why failing on CI workflow")]
         [ANCMTestFlags(ANCMTestCondition)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]

--- a/tools/install_hosting_bundle.ps1
+++ b/tools/install_hosting_bundle.ps1
@@ -1,0 +1,36 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+<#
+.SYNOPSIS
+    Install Windows Hosting Bundle referred by build/dependencies.props
+.DESCRIPTION
+    The script ensure that the ASP.NET shared framework is in place
+.PARAMETER dropLocation
+    The location of where the sharefx build drops can be found
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]
+    $dropLocation,
+
+    [switch]
+    $uninstall
+)
+
+
+$ErrorActionPreference = 'Stop'
+Import-Module -Name (Join-Path $PSScriptRoot versions.psm1) -Force
+
+$netCoreAppVersion = GetASPNETVersionUsedByBuild
+$buildNumber = ($netCoreAppVersion -split "-")[-1]
+$dropLocation = $dropLocation.Replace('${netCoreAppVersion}',$netCoreAppVersion).Replace('${buildNumber}',$buildNumber)
+
+if ($uninstall) {
+    & $dropLocation /uninstall /quiet
+} else {
+    & $dropLocation /install /quiet
+}


### PR DESCRIPTION
Some of these test are failing on CI workflow. I would like to disable them for now and create an issue to investigate them

* Timeout tests intermittently fails. This is kind of known to me but I have not debugged them yet
* ClientCertificateMappingTest fails only when the tests are run in series. When running them isolated they do not fail. This need to be fixed